### PR TITLE
Introduce workspace config mode

### DIFF
--- a/api/workspace_api.go
+++ b/api/workspace_api.go
@@ -282,10 +282,10 @@ func (ctrl *Controller) UpdateWorkspaceHandler(c *gin.Context) {
 		return
 	}
 
-	// Validate configMode if provided
+	// Set default configMode if not provided or validate if provided
 	configMode := workspaceReq.ConfigMode
 	if configMode == "" {
-		configMode = workspace.ConfigMode // Keep existing configMode if not provided
+		configMode = "merge"
 	} else if !isValidConfigMode(configMode) {
 		ctrl.ErrorHandler(c, http.StatusBadRequest, errors.New("ConfigMode must be one of: 'local', 'workspace', 'merge'"))
 		return

--- a/dev/dev_context.go
+++ b/dev/dev_context.go
@@ -275,59 +275,38 @@ func getConfigs(ctx workflow.Context, workspaceId string) (common.LocalPublicCon
 			finalEmbeddingConfig = workspaceConfig.Embedding
 		case "merge":
 			// Merge configurations - workspace config overrides local config if present
-			finalLLMConfig = localConfig.LLM
-			finalEmbeddingConfig = localConfig.Embedding
-
-			if len(workspaceConfig.LLM.Defaults) > 0 {
-				finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
-			}
-			for key, models := range workspaceConfig.LLM.UseCaseConfigs {
-				finalLLMConfig.UseCaseConfigs[key] = models
-			}
-			if len(workspaceConfig.Embedding.Defaults) > 0 {
-				finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
-			}
-			for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
-				finalEmbeddingConfig.UseCaseConfigs[key] = models
-			}
+			finalLLMConfig, finalEmbeddingConfig = mergeConfigs(localConfig.LLM, localConfig.Embedding, workspaceConfig.LLM, workspaceConfig.Embedding)
 		default:
 			// Default to merge mode for backward compatibility
-			finalLLMConfig = localConfig.LLM
-			finalEmbeddingConfig = localConfig.Embedding
-
-			if len(workspaceConfig.LLM.Defaults) > 0 {
-				finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
-			}
-			for key, models := range workspaceConfig.LLM.UseCaseConfigs {
-				finalLLMConfig.UseCaseConfigs[key] = models
-			}
-			if len(workspaceConfig.Embedding.Defaults) > 0 {
-				finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
-			}
-			for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
-				finalEmbeddingConfig.UseCaseConfigs[key] = models
-			}
+			finalLLMConfig, finalEmbeddingConfig = mergeConfigs(localConfig.LLM, localConfig.Embedding, workspaceConfig.LLM, workspaceConfig.Embedding)
 		}
 	} else {
 		// Legacy behavior: always merge configurations - workspace config overrides local config if present
-		finalLLMConfig = localConfig.LLM
-		finalEmbeddingConfig = localConfig.Embedding
-
-		if len(workspaceConfig.LLM.Defaults) > 0 {
-			finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
-		}
-		for key, models := range workspaceConfig.LLM.UseCaseConfigs {
-			finalLLMConfig.UseCaseConfigs[key] = models
-		}
-		if len(workspaceConfig.Embedding.Defaults) > 0 {
-			finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
-		}
-		for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
-			finalEmbeddingConfig.UseCaseConfigs[key] = models
-		}
+		finalLLMConfig, finalEmbeddingConfig = mergeConfigs(localConfig.LLM, localConfig.Embedding, workspaceConfig.LLM, workspaceConfig.Embedding)
 	}
 
 	return localConfig, workspaceConfig, finalLLMConfig, finalEmbeddingConfig, nil
+}
+
+// mergeConfigs merges local and workspace configurations with workspace config overriding local config
+func mergeConfigs(localLLM common.LLMConfig, localEmbedding common.EmbeddingConfig, workspaceLLM common.LLMConfig, workspaceEmbedding common.EmbeddingConfig) (common.LLMConfig, common.EmbeddingConfig) {
+	finalLLMConfig := localLLM
+	finalEmbeddingConfig := localEmbedding
+
+	if len(workspaceLLM.Defaults) > 0 {
+		finalLLMConfig.Defaults = workspaceLLM.Defaults
+	}
+	for key, models := range workspaceLLM.UseCaseConfigs {
+		finalLLMConfig.UseCaseConfigs[key] = models
+	}
+	if len(workspaceEmbedding.Defaults) > 0 {
+		finalEmbeddingConfig.Defaults = workspaceEmbedding.Defaults
+	}
+	for key, models := range workspaceEmbedding.UseCaseConfigs {
+		finalEmbeddingConfig.UseCaseConfigs[key] = models
+	}
+
+	return finalLLMConfig, finalEmbeddingConfig
 }
 
 type DevActionContext struct {

--- a/dev/dev_context.go
+++ b/dev/dev_context.go
@@ -249,22 +249,84 @@ func getConfigs(ctx workflow.Context, workspaceId string) (common.LocalPublicCon
 		return localConfig, workspaceConfig, common.LLMConfig{}, common.EmbeddingConfig{}, fmt.Errorf("failed to get workspace config: %v", err)
 	}
 
-	// Merge configurations - workspace config overrides local config if present
-	finalLLMConfig := localConfig.LLM
-	finalEmbeddingConfig := localConfig.Embedding
+	// Check if workspace config mode feature is enabled
+	enableConfigMode := workflow.GetVersion(ctx, "workspace-config-mode", workflow.DefaultVersion, 1) >= 1
 
-	if len(workspaceConfig.LLM.Defaults) > 0 {
-		finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
+	// Apply configuration based on configMode (if enabled)
+	var finalLLMConfig common.LLMConfig
+	var finalEmbeddingConfig common.EmbeddingConfig
+
+	if enableConfigMode {
+		// Get workspace details to access configMode
+		var workspace domain.Workspace
+		err = workflow.ExecuteActivity(ctx, wa.GetWorkspace, workspaceId).Get(ctx, &workspace)
+		if err != nil {
+			return localConfig, workspaceConfig, common.LLMConfig{}, common.EmbeddingConfig{}, fmt.Errorf("failed to get workspace: %v", err)
+		}
+
+		switch workspace.ConfigMode {
+		case "local":
+			// Use only local config, ignore workspace config
+			finalLLMConfig = localConfig.LLM
+			finalEmbeddingConfig = localConfig.Embedding
+		case "workspace":
+			// Use only workspace config, ignore local config
+			finalLLMConfig = workspaceConfig.LLM
+			finalEmbeddingConfig = workspaceConfig.Embedding
+		case "merge":
+			// Merge configurations - workspace config overrides local config if present
+			finalLLMConfig = localConfig.LLM
+			finalEmbeddingConfig = localConfig.Embedding
+
+			if len(workspaceConfig.LLM.Defaults) > 0 {
+				finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
+			}
+			for key, models := range workspaceConfig.LLM.UseCaseConfigs {
+				finalLLMConfig.UseCaseConfigs[key] = models
+			}
+			if len(workspaceConfig.Embedding.Defaults) > 0 {
+				finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
+			}
+			for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
+				finalEmbeddingConfig.UseCaseConfigs[key] = models
+			}
+		default:
+			// Default to merge mode for backward compatibility
+			finalLLMConfig = localConfig.LLM
+			finalEmbeddingConfig = localConfig.Embedding
+
+			if len(workspaceConfig.LLM.Defaults) > 0 {
+				finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
+			}
+			for key, models := range workspaceConfig.LLM.UseCaseConfigs {
+				finalLLMConfig.UseCaseConfigs[key] = models
+			}
+			if len(workspaceConfig.Embedding.Defaults) > 0 {
+				finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
+			}
+			for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
+				finalEmbeddingConfig.UseCaseConfigs[key] = models
+			}
+		}
+	} else {
+		// Legacy behavior: always merge configurations - workspace config overrides local config if present
+		finalLLMConfig = localConfig.LLM
+		finalEmbeddingConfig = localConfig.Embedding
+
+		if len(workspaceConfig.LLM.Defaults) > 0 {
+			finalLLMConfig.Defaults = workspaceConfig.LLM.Defaults
+		}
+		for key, models := range workspaceConfig.LLM.UseCaseConfigs {
+			finalLLMConfig.UseCaseConfigs[key] = models
+		}
+		if len(workspaceConfig.Embedding.Defaults) > 0 {
+			finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
+		}
+		for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
+			finalEmbeddingConfig.UseCaseConfigs[key] = models
+		}
 	}
-	for key, models := range workspaceConfig.LLM.UseCaseConfigs {
-		finalLLMConfig.UseCaseConfigs[key] = models
-	}
-	if len(workspaceConfig.Embedding.Defaults) > 0 {
-		finalEmbeddingConfig.Defaults = workspaceConfig.Embedding.Defaults
-	}
-	for key, models := range workspaceConfig.Embedding.UseCaseConfigs {
-		finalEmbeddingConfig.UseCaseConfigs[key] = models
-	}
+
 	return localConfig, workspaceConfig, finalLLMConfig, finalEmbeddingConfig, nil
 }
 

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -13,6 +13,7 @@ type Workspace struct {
 	Id           string    `json:"id"`
 	Name         string    `json:"name"`         // name of the workspace
 	LocalRepoDir string    `json:"localRepoDir"` // local code repository directory
+	ConfigMode   string    `json:"configMode"`   // configuration mode: 'local', 'workspace', or 'merge'
 	Created      time.Time `json:"created"`      // creation timestamp of the workspace
 	Updated      time.Time `json:"updated"`      // last update timestamp of the workspace
 }

--- a/env/environment.go
+++ b/env/environment.go
@@ -49,7 +49,6 @@ type LocalGitWorktreeEnv struct {
 }
 
 type LocalEnvParams struct {
-	WorkspaceId string
 	RepoDir     string
 	StartBranch *string
 }

--- a/env/environment_test.go
+++ b/env/environment_test.go
@@ -19,8 +19,7 @@ import (
 func TestLocalEnvironment(t *testing.T) {
 	ctx := context.Background()
 	params := LocalEnvParams{
-		WorkspaceId: "workspace1",
-		RepoDir:     "./",
+		RepoDir: "./",
 	}
 
 	env, err := NewLocalEnv(ctx, params)
@@ -47,7 +46,6 @@ func TestLocalGitWorktreeEnvironment(t *testing.T) {
 	repoDir, err := filepath.Abs("./")
 	require.NoError(t, err)
 	params := LocalEnvParams{
-		WorkspaceId: "workspace1",
 		RepoDir:     repoDir,
 		StartBranch: utils.Ptr("main"),
 	}
@@ -59,7 +57,7 @@ func TestLocalGitWorktreeEnvironment(t *testing.T) {
 		FlowId:      "flow_" + uniqueId,
 		Name:        "side/" + branchName,
 		Created:     time.Now(),
-		WorkspaceId: params.WorkspaceId,
+		WorkspaceId: "workspace1",
 	}
 
 	env, err := NewLocalGitWorktreeEnv(ctx, params, worktree)
@@ -89,8 +87,7 @@ func TestLocalGitWorktreeEnvironment(t *testing.T) {
 func TestLocalEnvironment_MarshalUnmarshal(t *testing.T) {
 	ctx := context.Background()
 	params := LocalEnvParams{
-		WorkspaceId: "workspace1",
-		RepoDir:     "./",
+		RepoDir: "./",
 	}
 
 	originalEnv, err := NewLocalEnv(ctx, params)
@@ -110,7 +107,6 @@ func TestLocalEnvironment_MarshalUnmarshal(t *testing.T) {
 func TestLocalGitWorktreeEnvironment_MarshalUnmarshal(t *testing.T) {
 	ctx := context.Background()
 	params := LocalEnvParams{
-		WorkspaceId: "workspace1",
 		RepoDir:     "./",
 		StartBranch: utils.Ptr("main"),
 	}
@@ -121,7 +117,7 @@ func TestLocalGitWorktreeEnvironment_MarshalUnmarshal(t *testing.T) {
 		FlowId:      "flow_" + uniqueId,
 		Name:        "side/test-feature-branch-" + uniqueId,
 		Created:     time.Now(),
-		WorkspaceId: params.WorkspaceId,
+		WorkspaceId: "workspace1",
 	}
 
 	originalEnv, err := NewLocalGitWorktreeEnv(ctx, params, worktree)

--- a/frontend/src/components/TaskModal.vue
+++ b/frontend/src/components/TaskModal.vue
@@ -7,7 +7,7 @@
       <label>Flow</label>
       <SegmentedControl v-model="flowType" :options="flowTypeOptions" />
       </div>
-      <div v-if="devMode">
+      <div>
         <label>Workdir</label>
         <SegmentedControl v-model="envType" :options="envTypeOptions" />
 

--- a/frontend/src/components/WorkspaceForm.vue
+++ b/frontend/src/components/WorkspaceForm.vue
@@ -9,6 +9,23 @@
       <input id="localRepoDir" v-model="localRepoDir" required>
     </div>
     <div>
+      <h3>Configuration Mode</h3>
+      <div class="config-mode-options">
+        <label class="radio-option">
+          <input type="radio" v-model="configMode" value="local" name="configMode">
+          Defer to local config
+        </label>
+        <label class="radio-option">
+          <input type="radio" v-model="configMode" value="workspace" name="configMode">
+          Use workspace only
+        </label>
+        <label class="radio-option">
+          <input type="radio" v-model="configMode" value="merge" name="configMode">
+          Merge configs
+        </label>
+      </div>
+    </div>
+    <div>
       <h3>LLMs</h3>
       <ModelConfigSelector
         v-model="llmConfig.defaults"
@@ -60,6 +77,7 @@ const emit = defineEmits<{
 
 const name = ref('');
 const localRepoDir = ref('');
+const configMode = ref('merge');
 const getEmptyUseCaseConfigs = () => { return {'': [{ provider: '', model: '' }]}}
 const llmConfig = ref<LLMConfig>({ 
   defaults: props.workspace.llmConfig?.defaults?.length ? [...props.workspace.llmConfig.defaults] : [{ provider: '', model: '' }], 
@@ -109,6 +127,7 @@ onMounted(() => {
   if (props.workspace) {
     name.value = props.workspace.name;
     localRepoDir.value = props.workspace.localRepoDir;
+    configMode.value = props.workspace.configMode || 'merge';
   }
 });
 
@@ -127,6 +146,7 @@ const submitWorkspace = async () => {
   const formData: Omit<Workspace, 'id'> = {
     name: name.value,
     localRepoDir: localRepoDir.value,
+    configMode: configMode.value,
     llmConfig: filterEmptyUseCaseKeys(llmConfig.value),
     embeddingConfig: filterEmptyUseCaseKeys(embeddingConfig.value)
   };
@@ -188,5 +208,22 @@ form {
   color: var(--color-text-inverse);
   border: none;
   border-radius: 0.25rem;
+}
+
+.config-mode-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.radio-option input[type="radio"] {
+  margin: 0;
 }
 </style>

--- a/frontend/src/components/WorkspaceForm.vue
+++ b/frontend/src/components/WorkspaceForm.vue
@@ -10,22 +10,13 @@
     </div>
     <div>
       <h3>Configuration Mode</h3>
-      <div class="config-mode-options">
-        <label class="radio-option">
-          <input type="radio" v-model="configMode" value="local" name="configMode">
-          Defer to local config
-        </label>
-        <label class="radio-option">
-          <input type="radio" v-model="configMode" value="workspace" name="configMode">
-          Use workspace only
-        </label>
-        <label class="radio-option">
-          <input type="radio" v-model="configMode" value="merge" name="configMode">
-          Merge configs
-        </label>
-      </div>
+      <select v-model="configMode" class="config-mode-select">
+        <option value="local">Local only</option>
+        <option value="workspace">Workspace only</option>
+        <option value="merge">Merge</option>
+      </select>
     </div>
-    <div>
+    <div v-show="configMode !== 'local'">
       <h3>LLMs</h3>
       <ModelConfigSelector
         v-model="llmConfig.defaults"
@@ -47,7 +38,7 @@
         </template>
       </ExpandableSection>
     </div>
-    <div>
+    <div v-show="configMode !== 'local'">
       <h3>Embeddings</h3>
       <!-- Note: Embeddings do not support use case configs yet, even though
       embedding config does, so don't show them in the UI -->
@@ -210,20 +201,14 @@ form {
   border-radius: 0.25rem;
 }
 
-.config-mode-options {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.radio-option {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-
-.radio-option input[type="radio"] {
-  margin: 0;
+select {
+  --select-background-color: var(--color-background-hover);
+  padding: 0.2rem;
+  font-size: 0.9rem;
+  background-color: var(--select-background-color);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-contrast);
+  border-radius: 0.25rem;
+  margin-right: 0.5rem;
 }
 </style>

--- a/frontend/src/components/__tests__/WorkspaceForm.spec.ts
+++ b/frontend/src/components/__tests__/WorkspaceForm.spec.ts
@@ -13,6 +13,7 @@ describe('WorkspaceForm.vue', () => {
         workspace: {
           name: '',
           localRepoDir: '',
+          configMode: 'merge',
           llmConfig: {
             defaults: [],
             useCaseConfigs: {}
@@ -37,6 +38,7 @@ describe('WorkspaceForm.vue', () => {
       body: JSON.stringify({
         name: 'New Workspace',
         localRepoDir: '/local/repo/dir',
+        configMode: 'merge',
         llmConfig: { defaults: [{ provider: 'openai', model: '' }], useCaseConfigs: {} },
         embeddingConfig: { defaults: [{ provider: 'openai', model: '' }], useCaseConfigs: {} }
       }),
@@ -60,6 +62,7 @@ describe('WorkspaceForm.vue', () => {
       id: '456',
       name: 'Existing Workspace',
       localRepoDir: '/existing/repo/dir',
+      configMode: 'merge',
       llmConfig: {
         defaults: [{ provider: 'anthropic', model: '' }],
         useCaseConfigs: {}
@@ -86,6 +89,7 @@ describe('WorkspaceForm.vue', () => {
       body: JSON.stringify({
         name: 'Updated Workspace',
         localRepoDir: '/updated/repo/dir',
+        configMode: 'merge',
         llmConfig: {
           defaults: [{ provider: 'openai', model: '' }],
           useCaseConfigs: {}
@@ -112,6 +116,7 @@ describe('WorkspaceForm.vue', () => {
       id: '789',
       name: 'Existing Workspace',
       localRepoDir: '/existing/repo/dir',
+      configMode: 'merge',
       llmConfig: {
         defaults: [{ provider: 'anthropic', model: '' }],
         useCaseConfigs: {}

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -17,6 +17,7 @@ export interface Workspace {
   id?: string
   name: string
   localRepoDir: string
+  configMode?: string
   llmConfig?: LLMConfig | null
   embeddingConfig?: EmbeddingConfig | null
 }

--- a/srv/redis/workspace_test.go
+++ b/srv/redis/workspace_test.go
@@ -15,7 +15,11 @@ import (
 func TestPersistWorkspace(t *testing.T) {
 	ctx := context.Background()
 	db := NewTestRedisStorage()
-	workspace := domain.Workspace{Id: "123", Name: "TestWorkspace"}
+	workspace := domain.Workspace{
+		Id:         "123",
+		Name:       "TestWorkspace",
+		ConfigMode: "merge",
+	}
 
 	// Test will try to persist the workspace
 	err := db.PersistWorkspace(ctx, workspace)
@@ -39,6 +43,10 @@ func TestPersistWorkspace(t *testing.T) {
 		t.Errorf("expected workspace name %s, got %s", workspace.Name, persistedWorkspace.Name)
 	}
 
+	if persistedWorkspace.ConfigMode != workspace.ConfigMode {
+		t.Errorf("expected workspace configMode %s, got %s", workspace.ConfigMode, persistedWorkspace.ConfigMode)
+	}
+
 	// Verifying storage in new sorted set structure
 	workspaceNameIds, err := db.Client.ZRange(ctx, "global:workspaces", 0, -1).Result()
 	assert.Nil(t, err)
@@ -53,6 +61,9 @@ func TestPersistWorkspace(t *testing.T) {
 	assert.Nil(t, err)
 	if workspaces[0].Id != workspace.Id {
 		t.Errorf("expected workspace id %s, got %s", workspace.Id, workspaces[0].Id)
+	}
+	if workspaces[0].ConfigMode != workspace.ConfigMode {
+		t.Errorf("expected workspace configMode %s, got %s", workspace.ConfigMode, workspaces[0].ConfigMode)
 	}
 }
 

--- a/srv/sqlite/migrations/011_add_config_mode_to_workspaces.down.sql
+++ b/srv/sqlite/migrations/011_add_config_mode_to_workspaces.down.sql
@@ -1,0 +1,2 @@
+-- Remove config_mode column from workspaces table
+ALTER TABLE workspaces DROP COLUMN config_mode;

--- a/srv/sqlite/migrations/011_add_config_mode_to_workspaces.up.sql
+++ b/srv/sqlite/migrations/011_add_config_mode_to_workspaces.up.sql
@@ -1,0 +1,5 @@
+-- Add config_mode column to workspaces table
+ALTER TABLE workspaces ADD COLUMN config_mode TEXT NOT NULL DEFAULT 'merge';
+
+-- Set all existing workspaces to 'merge' mode to maintain current behavior
+UPDATE workspaces SET config_mode = 'merge' WHERE config_mode IS NULL OR config_mode = '';

--- a/srv/sqlite/migrations/011_add_config_mode_to_workspaces.up.sql
+++ b/srv/sqlite/migrations/011_add_config_mode_to_workspaces.up.sql
@@ -1,5 +1,1 @@
--- Add config_mode column to workspaces table
 ALTER TABLE workspaces ADD COLUMN config_mode TEXT NOT NULL DEFAULT 'merge';
-
--- Set all existing workspaces to 'merge' mode to maintain current behavior
-UPDATE workspaces SET config_mode = 'merge' WHERE config_mode IS NULL OR config_mode = '';

--- a/srv/sqlite/workspace.go
+++ b/srv/sqlite/workspace.go
@@ -14,14 +14,15 @@ import (
 
 func (s *Storage) PersistWorkspace(ctx context.Context, workspace domain.Workspace) error {
 	query := `
-		INSERT OR REPLACE INTO workspaces (id, name, local_repo_dir, created, updated)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT OR REPLACE INTO workspaces (id, name, local_repo_dir, config_mode, created, updated)
+		VALUES (?, ?, ?, ?, ?, ?)
 	`
 
 	_, err := s.db.ExecContext(ctx, query,
 		workspace.Id,
 		workspace.Name,
 		workspace.LocalRepoDir,
+		workspace.ConfigMode,
 		workspace.Created.UTC().Truncate(time.Millisecond),
 		workspace.Updated.UTC().Truncate(time.Millisecond),
 	)
@@ -42,7 +43,7 @@ func (s *Storage) PersistWorkspace(ctx context.Context, workspace domain.Workspa
 
 func (s *Storage) GetWorkspace(ctx context.Context, workspaceId string) (domain.Workspace, error) {
 	query := `
-		SELECT id, name, local_repo_dir, created, updated
+		SELECT id, name, local_repo_dir, config_mode, created, updated
 		FROM workspaces
 		WHERE id = ?
 	`
@@ -52,6 +53,7 @@ func (s *Storage) GetWorkspace(ctx context.Context, workspaceId string) (domain.
 		&workspace.Id,
 		&workspace.Name,
 		&workspace.LocalRepoDir,
+		&workspace.ConfigMode,
 		&workspace.Created,
 		&workspace.Updated,
 	)
@@ -71,7 +73,7 @@ func (s *Storage) GetWorkspace(ctx context.Context, workspaceId string) (domain.
 
 func (s *Storage) GetAllWorkspaces(ctx context.Context) ([]domain.Workspace, error) {
 	query := `
-		SELECT id, name, local_repo_dir, created, updated
+		SELECT id, name, local_repo_dir, config_mode, created, updated
 		FROM workspaces
 		ORDER BY name
 	`
@@ -90,6 +92,7 @@ func (s *Storage) GetAllWorkspaces(ctx context.Context) ([]domain.Workspace, err
 			&workspace.Id,
 			&workspace.Name,
 			&workspace.LocalRepoDir,
+			&workspace.ConfigMode,
 			&workspace.Created,
 			&workspace.Updated,
 		)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -148,10 +148,7 @@ func StartWorker(hostPort string, taskQueue string) worker.Worker {
 	w.RegisterActivity(ffa.EvalBoolFlag)
 	w.RegisterActivity(common.GetLocalConfig)
 
-	workspaceActivities := &workspace.Activities{
-		Storage: service,
-	}
-	w.RegisterActivity(workspaceActivities.GetWorkspaceConfig)
+	w.RegisterActivity(&workspace.Activities{Storage: service})
 
 	err = w.Start()
 	if err != nil {

--- a/workspace/activities.go
+++ b/workspace/activities.go
@@ -10,6 +10,15 @@ type Activities struct {
 	Storage srv.Storage
 }
 
+func (a *Activities) GetWorkspace(workspaceID string) (domain.Workspace, error) {
+	ctx := context.Background()
+	workspace, err := a.Storage.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return domain.Workspace{}, err
+	}
+	return workspace, nil
+}
+
 func (a *Activities) GetWorkspaceConfig(workspaceID string) (domain.WorkspaceConfig, error) {
 	ctx := context.Background()
 	config, err := a.Storage.GetWorkspaceConfig(ctx, workspaceID)


### PR DESCRIPTION
Workspaces can be set up to either:

1. Defer completely to a local config (shared across workspaces)
2. Use only the workspace config
3. Merge configs (the previous default), with workspace overriding local