### PR TITLE
Version-gated delegation in GetUserGuidance to reuse paused-guidance …

### DIFF
--- a/dev/user_request.go
+++ b/dev/user_request.go
@@ -281,6 +281,11 @@ would mean to apply it to your current situation.
 		}, nil
 	}
 
+	v := workflow.GetVersion(dCtx, "guidance-delegate-when-paused", workflow.DefaultVersion, 1)
+	if v == 1 && dCtx.GlobalState != nil && dCtx.GlobalState.Paused {
+		return UserRequestIfPaused(dCtx, guidanceContext, requestParams)
+	}
+
 	guidanceRequest := &RequestForUser{
 		OriginWorkflowId: workflow.GetInfo(dCtx).WorkflowExecution.ID,
 		Subflow:          dCtx.FlowScope.SubflowName,


### PR DESCRIPTION
…path

Edit dev/user_request.go, function GetUserGuidance:
- After the existing DisableHumanInTheLoop check and before constructing guidanceRequest, insert a Temporal version gate: v := workflow.GetVersion(dCtx, "guidance-delegate-when-paused", workflow.DefaultVersion, 1).
- If v == 1 AND dCtx.GlobalState != nil AND dCtx.GlobalState.Paused is true, immediately return UserRequestIfPaused(dCtx, guidanceContext, requestParams). Do not create a RequestForUser or call TrackHuman in this branch, and do not wrap content.
- Otherwise retain legacy behavior: construct RequestForUser with RequestKindFreeForm, track with action name "user_request.guidance" via TrackHuman, call GetUserResponse, and wrap non-empty response content with the existing START/END markers.
- Ensure imports remain valid; workflow is already imported in this file.
- Do not modify any other files or behaviors.